### PR TITLE
Add cclm-rcs-paraso

### DIFF
--- a/easybuild/easyconfigs/c/CCLM-rcs/CCLM-rcs-paraso-coupled-iimpi-2023a.eb
+++ b/easybuild/easyconfigs/c/CCLM-rcs/CCLM-rcs-paraso-coupled-iimpi-2023a.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name='CCLM-rcs-paraso-coupled'
+version='v1.0'
+
+homepage = 'https://oasis.cerfacs.fr/en/home/'
+description = """COSMO-CLM it is the climate version of the COSMO LM model 
+(Steppeler et al., 2003), which is the operational non-hydrostatic 
+mesoscale weather forecast model developed initially by the German Weather 
+Service (DWD) and then by the European Consortium COSMO. The RCM COSMO CLM 
+is currently developed by the CLM-Community, with which CMCC collaborates since 2008.
+"""
+
+toolchain = {'name': 'iimpi', 'version': '2023a'}
+toolchainopts = {'optarch': False, # Disable automatic architecture optimization
+                 'usempi': True,
+}
+
+
+sources = [{
+             'filename': 'cclm_rcs_paraso_coupled_%(version)s.tar.gz',
+             'git_config': {
+                 'url': 'git@gitlab.kuleuven.be:rcs/cclm',
+                 'repo_name': 'cclm_rcs',
+                 'tag': 'paraso_coupled_%(version)s',
+    },
+}]
+
+builddependencies = [('CMake', '3.26.3'),]
+
+dependencies = [('netCDF-Fortran', '4.6.1'),
+                ('ecCodes', '2.31.0'),
+                ('OASIS3-MCT-rcs-paraso-coupled', 'v1.0')]
+
+sanity_check_paths = {
+    'files': ['bin/cclm'],
+    'dirs': [],
+}
+
+moduleclass = 'geo'


### PR DESCRIPTION
Adding the first CCLM_rcs easyconfig. This one specifically for the PARASO coupled model. 