### PR TITLE
extra flags for compilation on AMD nodes

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.14.5-iimpi-2024a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.14.5-iimpi-2024a.eb
@@ -8,7 +8,12 @@ description = """HDF5 is a data model, library, and file format for storing and 
  and efficient I/O and for high volume and complex data."""
 
 toolchain = {'name': 'iimpi', 'version': '2024a'}
-toolchainopts = {'pic': True, 'usempi': True}
+toolchainopts = {
+    'pic': True, 'usempi': True,
+    'extra_cflags': '-march=core-avx2 -mno-shstk',
+    'extra_fcflags': '-march=core-avx2 -mno-shstk', 
+    'extra_cxxflags': '-march=core-avx2 -mno-shstk',
+}
 
 source_urls = ['https://github.com/HDFGroup/hdf5/archive']
 sources = ['hdf5_%(version)s.tar.gz']


### PR DESCRIPTION
As some intel easyconfigs do not compile as is on AMD nodes, I have added these flags to the toolchain options. I am not sure if this is the best approach though. Any thoughts @scorveleyn ?