### PR TITLE
Modify papi

### DIFF
--- a/easybuild/easyconfigs/p/PAPI/PAPI-5.6.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/p/PAPI/PAPI-5.6.0-GCCcore-12.3.0.eb
@@ -23,11 +23,8 @@ toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 
 source_urls = ['https://icl.utk.edu/projects/papi/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-patches = ['%(name)s-%(version)s_remove_warning_as_error_flag.patch']
 checksums = [
     {'papi-5.6.0.tar.gz': '49b7293f9ca2d74d6d80bd06b5c4be303663123267b4ac0884cbcae4c914dc47'},
-    {'PAPI-5.6.0_remove_warning_as_error_flag.patch':
-     '8b999e3c7390ef3db90e56bd3ec0b92fc8b6e72c10684c6fedff866d89619bc3'},
 ]
 
 builddependencies = [
@@ -36,6 +33,7 @@ builddependencies = [
 
 start_dir = 'src'
 
+preconfigopts = 'CFLAGS="$CFLAGS -Wno-format-truncation -Wno-use-after-free"'
 configopts = "--with-components=rapl "  # for energy measurements
 
 # There is also "fulltest" that is a superset of "test" but hangs on some processors


### PR DESCRIPTION
In my previous version of this easyconfig I completely turned off the treatment of warnings as errors, which was probably a bit too general. I specifically did this for the errors on which the compilation crashed. It would be preferable to fix the issues, but as these were not treated as errors with the compilers the software was originally compiled with, I chose to just ignore them. 