### PR TITLE
change versioning and add exe to path

### DIFF
--- a/easybuild/easyconfigs/c/CCLM-rcs/CCLM-rcs-paraso-coupled-iimpi-2023a.eb
+++ b/easybuild/easyconfigs/c/CCLM-rcs/CCLM-rcs-paraso-coupled-iimpi-2023a.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
-name='CCLM-rcs-paraso-coupled'
-version='v1.0'
+name='CCLM-rcs'
+version='paraso-coupled-v1.0'
 
 homepage = 'https://www.clm-community.eu/COSMO-CLM/Overview/'
 description = """COSMO-CLM it is the climate version of the COSMO LM model 
@@ -18,11 +18,11 @@ toolchainopts = {'optarch': False, # Disable automatic architecture optimization
 
 
 sources = [{
-             'filename': 'cclm_rcs_paraso_coupled_%(version)s.tar.gz',
+             'filename': 'cclm_rcs_%(version)s.tar.gz',
              'git_config': {
                  'url': 'git@gitlab.kuleuven.be:rcs/cclm',
                  'repo_name': 'cclm_rcs',
-                 'tag': 'paraso_coupled_%(version)s',
+                 'tag': '%(version)s',
     },
 }]
 
@@ -30,11 +30,15 @@ builddependencies = [('CMake', '3.26.3'),]
 
 dependencies = [('netCDF-Fortran', '4.6.1'),
                 ('ecCodes', '2.31.0'),
-                ('OASIS3-MCT-rcs-paraso-coupled', 'v1.0')]
+                ('OASIS3-MCT-rcs', 'paraso-coupled-v1.0')]
 
 sanity_check_paths = {
     'files': ['bin/cclm'],
     'dirs': [],
+}
+
+modextrapaths = {
+      'PATH': ['bin'],
 }
 
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/f/f.ETISh-rcs/f.ETISh-rcs-paraso-coupled-v1.0.eb
+++ b/easybuild/easyconfigs/f/f.ETISh-rcs/f.ETISh-rcs-paraso-coupled-v1.0.eb
@@ -27,4 +27,8 @@ sanity_check_paths = {
     'dirs': ['bin'],
 }
 
+modextrapaths = {
+    'PATH': ['bin'],
+}
+
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/n/NEMO-rcs/NEMO-rcs-paraso-coupled-v1.0-iimpi-2023a.eb
+++ b/easybuild/easyconfigs/n/NEMO-rcs/NEMO-rcs-paraso-coupled-v1.0-iimpi-2023a.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
-name='NEMO-rcs-paraso-coupled'
-version='v1.0'
+name='NEMO-rcs'
+version='paraso-coupled-v1.0'
 
 homepage = 'https://www.nemo-ocean.eu/'
 description = """The 'Nucleus for European Modelling of the Ocean' (NEMO) is
@@ -14,19 +14,19 @@ toolchainopts = {'optarch': False, # Disable automatic architecture optimization
 }
 
 sources = [{
-             'filename': 'nemo_rcs_paraso_coupled_%(version)s.tar.gz',
+             'filename': 'nemo_rcs_%(version)s.tar.gz',
              'git_config': {
                  'url': 'git@gitlab.kuleuven.be:rcs/cclm/software',
                  'repo_name': 'nemo_rcs',
-                 'tag': 'paraso_coupled_%(version)s',
+                 'tag': '%(version)s',
     },
 }]
 
 builddependencies = [('CMake', '3.26.3'),]
 
 dependencies = [('netCDF-Fortran', '4.6.1'),
-                ('OASIS3-MCT-rcs-paraso-coupled', 'v1.0'),
-                ('XIOS-rcs-paraso-coupled', 'v1.0'),
+                ('OASIS3-MCT-rcs', 'paraso-coupled-v1.0'),
+                ('XIOS-rcs', 'paraso-coupled-v1.0'),
 ]
 
 configopts = '-DTOOLS=REBUILD_NEMO'
@@ -36,4 +36,9 @@ sanity_check_paths = {
               'bin/rebuild_nemo.exe'],
     'dirs': ['bin',],
 }
+
+modextrapaths = {
+    'PATH': ['bin'],
+}
+
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/x/XIOS-rcs/XIOS-rcs-paraso-coupled-iimpi-2023a.eb
+++ b/easybuild/easyconfigs/x/XIOS-rcs/XIOS-rcs-paraso-coupled-iimpi-2023a.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
-name='XIOS-rcs-paraso-coupled'
-version='v1.0'
+name='XIOS-rcs'
+version='paraso-coupled-v1.0'
 
 homepage = 'https://forge.ipsl.jussieu.fr/ioserver'
 description = """XIOS is an 'I/O server' that can run alongside
@@ -14,11 +14,11 @@ toolchainopts = {'optarch': False, # Disable automatic architecture optimization
 }
 
 sources = [{
-             'filename': 'xios_rcs_paraso_coupled_%(version)s.tar.gz',
+             'filename': 'xios_rcs_%(version)s.tar.gz',
              'git_config': {
                  'url': 'git@gitlab.kuleuven.be:rcs/cclm/software',
                  'repo_name': 'xios_rcs',
-                 'tag': 'paraso_coupled_%(version)s',
+                 'tag': '%(version)s',
     },
 }]
 
@@ -26,7 +26,7 @@ builddependencies = [('CMake', '3.26.3'),]
 
 dependencies = [('netCDF-Fortran', '4.6.1'),
                 ('PAPI', '5.6.0'),
-                ('OASIS3-MCT-rcs-paraso-coupled', 'v1.0')]
+                ('OASIS3-MCT-rcs', 'paraso-coupled-v1.0')]
 
 sanity_check_paths = {
     'files': ['bin/xios_server.exe',
@@ -36,6 +36,10 @@ sanity_check_paths = {
     'dirs': ['bin',
              'inc',
              'lib'],
+}
+
+modextrapaths = {
+    'PATH': ['bin'],
 }
 
 moduleclass = 'geo'


### PR DESCRIPTION
Mistakenly thought https://github.com/KUL-EES/easybuild-easyconfigs/pull/14 was already merged. Added the changes from there here, and closed that PR. Here I also add the executables to the $PATH variable.

Notes from PR14:



Some minor changes to the Paraso easyconfigs. The main change is the version for all of them. Instead of including the 'paraso-coupled' in the software name, I now decided to include this in the version. This results in the following naming for the modules:

<software>-rcs/paraso-coupled-v<version>-<toolchain>

or the more general approach I want to achieve:

<software>-rcs/<branch-name>-v<version>-<toolchain>

<branch-name>-v<version> should also be the tag name. I added some info about that in the wiki as well.

Based on your previous comments, I also revised the convention <software>-rcs, but I eventually decided to keep this, as this means that I have to add a double version in the software: the upstream version of the software and the internal tag version. As software for a projects tends to keep the same version, this shouldn't be too much of an issue
